### PR TITLE
Bug fix for indexing 0-dim tensor in utils/test.py

### DIFF
--- a/utils/test.py
+++ b/utils/test.py
@@ -21,7 +21,7 @@ def test(dataloader, net, criterion, optimizer, opt):
 
         output = net(init_input, annotation, adj_matrix)
 
-        test_loss += criterion(output, target).data[0]
+        test_loss += criterion(output, target).data.item()
         pred = output.data.max(1, keepdim=True)[1]
 
         correct += pred.eq(target.data.view_as(pred)).cpu().sum()


### PR DESCRIPTION
## Error Message

Error message when running main.py:

```
Traceback (most recent call last):
  File "main.py", line 72, in <module>
    main(opt)
  File "main.py", line 68, in main
    test(test_dataloader, net, criterion, optimizer, opt)
  File ".../ggnn.pytorch/utils/test.py", line 24, in test
    test_loss += criterion(output, target).data[0]
IndexError: invalid index of a 0-dim tensor. Use tensor.item() to convert a 0-dim tensor to a Python number
```

## Steps to reproduce:
1. Create a new virtualenv with python2.7.
2. `pip install torch numpy`
3. `python main.py`

## Suggested Reason

I believe the bug occured due to a depreciating of indexing 0-dim tensors in an update to PyTorch.

I have implemented the fix. 